### PR TITLE
fetch account on app load to avoid race conditions

### DIFF
--- a/src/Layout/index.js
+++ b/src/Layout/index.js
@@ -4,6 +4,7 @@ import './Layout.css'
 
 const Layout = ({
   className,
+  address,
   children,
   ...rest
 }) => (
@@ -16,7 +17,7 @@ const Layout = ({
         'decisions',
         'settings'
       ]}
-      address={'0xA1E4380A3B1f749673E270229993eE55F35663b4'}
+      address={address}
       balancePNK={242}
     />
     { children }

--- a/src/Sidebar/index.js
+++ b/src/Sidebar/index.js
@@ -4,24 +4,17 @@ import MenuSidebar from './MenuSidebar'
 import AccountLocked from './AccountLocked'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router-dom'
-import { balanceFetchData, fetchAddress } from '../business/ethereum/action-creators'
+import { balanceFetchData } from '../business/ethereum/action-creators'
 import './Sidebar.css'
 
 class Sidebar extends Component {
   componentWillMount () {
     this.props.getBalance()
-    this.props.getAddress()
   }
 
   render () {
-    const {balanceIsFetching, addressIsFetching, balanceHasErrored, addressHasErrored, items} = this.props
-    let balance = 0
-    let address = 'loading...'
-
-    if (!balanceIsFetching) balance = (this.props.balance.tokenBalance - this.props.balance.activatedTokens)
-    if (!addressIsFetching) address = this.props.address
-
-    if (addressHasErrored) {
+    const {balanceIsFetching, balanceHasErrored, items, address} = this.props
+    if (!address) {
       return (
         <div className='Sidebar-container'>
           <AccountLocked />
@@ -29,6 +22,8 @@ class Sidebar extends Component {
       )
     }
 
+    let balance = 0
+    if (!balanceIsFetching) balance = (this.props.balance.tokenBalance - this.props.balance.activatedTokens)
     if (balanceHasErrored) balance = -1
 
     return (
@@ -46,17 +41,13 @@ const mapStateToProps = state => {
   return {
     balance: state.ethereum.balance,
     balanceHasErrored: state.ethereum.failureBalance,
-    balanceIsFetching: state.ethereum.requestBalance,
-    address: state.ethereum.address,
-    addressHasErrored: state.ethereum.failureAddress,
-    addressIsFetching: state.ethereum.requestAddress
+    balanceIsFetching: state.ethereum.requestBalance
   }
 }
 
 const mapDispatchToProps = dispatch => {
   return {
     getBalance: () => dispatch(balanceFetchData()),
-    getAddress: () => dispatch(fetchAddress())
   }
 }
 

--- a/src/Sidebar/index.js
+++ b/src/Sidebar/index.js
@@ -47,7 +47,7 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = dispatch => {
   return {
-    getBalance: () => dispatch(balanceFetchData()),
+    getBalance: () => dispatch(balanceFetchData())
   }
 }
 

--- a/src/bootstrap/App.js
+++ b/src/bootstrap/App.js
@@ -28,12 +28,12 @@ class App extends Component {
     appLoaded: false
   }
 
-  componentWillMount() {
+  componentWillMount () {
     // fetch address before rendering app to make sure web3 has been loaded and to avoid race conditions
     this.props.getAddress()
   }
 
-  componentWillReceiveProps(nextProps) {
+  componentWillReceiveProps (nextProps) {
     // if address has loaded
     // FIXME handle error
     if (this.props.address === 0 && (nextProps.address || nextProps.address === null)) {
@@ -43,7 +43,7 @@ class App extends Component {
     }
   }
 
-  render() {
+  render () {
     // if no web3 show requires metamask page
     if (typeof window.web3 === 'undefined') {
       return (

--- a/src/business/ethereum/action-creators.js
+++ b/src/business/ethereum/action-creators.js
@@ -41,12 +41,10 @@ export const balanceFetchData = () => async dispatch => {
     let KlerosInstance = new Kleros(provider, process.env.REACT_APP_STORE_PROVIDER)
 
     let court = KlerosInstance.court
-    const account = await _getAccountSafe()
-    const balance = await court.getPNKBalance(process.env.REACT_APP_ARBITRATOR_ADDRESS, account)
+    const balance = await court.getPNKBalance(process.env.REACT_APP_ARBITRATOR_ADDRESS)
     dispatch(requestBalance(false))
     dispatch(receiveBalance(balance))
   } catch (e) {
-    console.log(e)
     // FIXME display a user-friendly error
     dispatch(failureBalance(true))
   }
@@ -61,6 +59,7 @@ export const fetchAddress = (account = 0) => async dispatch => {
     dispatch(receiveAddress(userAccount))
   } catch (e) {
     // FIXME display a user-friendly error
+    dispatch(requestAddress(false))
     dispatch(failureAddress(true))
   }
 }

--- a/src/business/ethereum/reducers.js
+++ b/src/business/ethereum/reducers.js
@@ -55,7 +55,7 @@ export function failureAddress (state = false, action) {
 export function address (state = 0x0, action) {
   switch (action.type) {
     case RECEIVE_ADDRESS:
-      return action.address
+      return action.address ? action.address : null
     default:
       return state
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,9 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import App from './bootstrap/App'
+import store from './bootstrap/store'
 
 ReactDOM.render(
-  <App />,
+  <App store={store} />,
   document.getElementById('root')
 )


### PR DESCRIPTION
app won't load until address has been fetched. this ensures that all other calls to API won't have a race condition with web3 initializing (i.e. account being undefined)