### PR TITLE
moved irr dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,17 +5,11 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@storybook/storybook-deployer": "^2.0.0",
-    "babel-eslint": "^8.0.1",
-    "babel-polyfill": "^6.26.0",
     "blockies": "^0.0.2",
     "blockies-identicon": "^0.1.0",
     "crypto-js": "^3.1.9-1",
-    "enzyme": "^3.2.0",
     "global": "^4.3.2",
     "kleros-api": "^0.0.47",
-    "node-sass-chokidar": "^0.0.3",
-    "npm-run-all": "^4.1.1",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "react-fontawesome": "^1.6.1",
@@ -25,16 +19,16 @@
     "redux-devtools-extension": "^2.13.2",
     "redux-form": "^7.0.4",
     "redux-thunk": "^2.2.0",
-    "storybook-router": "^0.2.9",
     "web3": "^0.20.1"
   },
   "devDependencies": {
     "@storybook/addon-actions": "^3.2.6",
+    "@storybook/storybook-deployer": "^2.0.0",
     "@storybook/addon-links": "^3.2.6",
     "@storybook/react": "^3.2.8",
-    "coveralls": "^3.0.0",
-    "enzyme-adapter-react-15": "^1.0.5",
-    "enzyme-to-json": "^3.3.0",
+    "storybook-router": "^0.2.9",
+    "babel-eslint": "^8.0.1",
+    "babel-polyfill": "^6.26.0",
     "eslint": "^4.9.0",
     "eslint-config-standard": "^10.2.1",
     "eslint-config-standard-jsx": "^4.0.2",
@@ -43,6 +37,12 @@
     "eslint-plugin-promise": "^3.6.0",
     "eslint-plugin-react": "^7.4.0",
     "eslint-plugin-standard": "^3.0.1",
+    "enzyme": "^3.2.0",
+    "enzyme-adapter-react-15": "^1.0.5",
+    "enzyme-to-json": "^3.3.0",
+    "coveralls": "^3.0.0",
+    "node-sass-chokidar": "^0.0.3",
+    "npm-run-all": "^4.1.1",
     "react-scripts": "1.0.13",
     "react-test-renderer": "^15.5.0"
   },
@@ -54,8 +54,10 @@
     "test:coverage": "npm test -- --coverage",
     "test:coveralls": "cat ./coverage/lcov.info | coveralls",
     "eject": "react-scripts eject",
-    "build-css": "node-sass-chokidar --include-path ./src --include-path ./node_modules src/ -o src/",
-    "watch-css": "npm run build-css && node-sass-chokidar --include-path ./src --include-path ./node_modules src/ -o src/ --watch --recursive",
+    "build-css":
+      "node-sass-chokidar --include-path ./src --include-path ./node_modules src/ -o src/",
+    "watch-css":
+      "npm run build-css && node-sass-chokidar --include-path ./src --include-path ./node_modules src/ -o src/ --watch --recursive",
     "lint": "./node_modules/.bin/eslint src",
     "lint-fix": "./node_modules/.bin/eslint src --fix",
     "storybook": "start-storybook -p 9009 -s public",
@@ -64,13 +66,8 @@
     "postinstall": "npm rebuild node-sass"
   },
   "jest": {
-    "snapshotSerializers": [
-      "enzyme-to-json/serializer"
-    ],
-    "collectCoverageFrom": [
-      "src/**/*.{js,jsx}",
-      "!<rootDir>/node_modules/"
-    ]
+    "snapshotSerializers": ["enzyme-to-json/serializer"],
+    "collectCoverageFrom": ["src/**/*.{js,jsx}", "!<rootDir>/node_modules/"]
   },
   "setupTestFrameworkScriptFile": "<rootDir>/src/setupTests.js"
 }


### PR DESCRIPTION
Issue https://github.com/kleros/kleros-front/issues/82
Moved the following dependencies to devDependencies as they are not required in the final build.
-    storybook/storybook-deployer: "^2.0.0",
-    "babel-eslint": "^8.0.1",
-    "babel-polyfill": "^6.26.0",
-    "enzyme": "^3.2.0",
-    "node-sass-chokidar": "^0.0.3",
-    "npm-run-all": "^4.1.1",
-    "storybook-router": "^0.2.9",
  